### PR TITLE
feat(codeql): extract dependency review into job [META-2960]

### DIFF
--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -51,16 +51,24 @@ jobs:
           AZURE_PACKAGING_PAT: ${{ secrets.AZURE_PACKAGING_PAT }}
           AZURE_MAVEN_REGISTRY: ${{ secrets.AZURE_MAVEN_REGISTRY }}
 
-      - name: Dependency Review
-        if: github.event.pull_request
-        uses: actions/dependency-review-action@v3
-        with:
-          # corporate dependency security and licensing settings must not be changed
-          # https://github.com/stgallerkb/.github-private/blob/main/security/dependency-review-config.yml
-          config-file: "stgallerkb/.github-private/security/dependency-review-config.yml@main"
-          external-repo-token: ${{ secrets.ORG_READ_ONLY }}
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:
           category: "/language:${{matrix.language}}"
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event.pull_request
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v3
+        with:
+          config-file: "stgallerkb/.github-private/security/dependency-review-config.yml@main"
+          external-repo-token: ${{ secrets.ORG_READ_ONLY }}


### PR DESCRIPTION
Dependency Review Action has been extracted into a separate job to eliminate matrix execution. Tested in: https://github.com/stgallerkb/next-playground/actions/runs/5736650601/job/15546672733